### PR TITLE
escape single quote with '' instead of \'

### DIFF
--- a/UNIX/Chapter03/pop-all-tables.sql
+++ b/UNIX/Chapter03/pop-all-tables.sql
@@ -15,7 +15,7 @@ insert into customer(title, fname, lname, addressline, town, zipcode, phone) val
 insert into customer(title, fname, lname, addressline, town, zipcode, phone) values('Mr','Dave','Jones','54 Vale Rise','Bingham','BG3 8GD','342 8264');
 insert into customer(title, fname, lname, addressline, town, zipcode, phone) values('Mr','Richard','Neill','42 Thatched Way','Winnersby','WB3 6GQ','505 6482');
 insert into customer(title, fname, lname, addressline, town, zipcode, phone) values('Mrs','Laura','Hardy','73 Margarita Way','Oxbridge','OX2 3HX','821 2335');
-insert into customer(title, fname, lname, addressline, town, zipcode, phone) values('Mr','Bill','O\'Neill','2 Beamer Street','Welltown','WT3 8GM','435 1234');
+insert into customer(title, fname, lname, addressline, town, zipcode, phone) values('Mr','Bill','O''Neill','2 Beamer Street','Welltown','WT3 8GM','435 1234');
 insert into customer(title, fname, lname, addressline, town, zipcode, phone) values('Mr','David','Hudson','4 The Square','Milltown','MT2 6RT','961 4526');
 
 -- Items


### PR DESCRIPTION
Properly escape single quote in O'Neill using two single quotes, instead of slash single quote.